### PR TITLE
fix: [#4] Implicit GH token instead of passing it

### DIFF
--- a/.github/workflows/mcvs-pr-validation.yml
+++ b/.github/workflows/mcvs-pr-validation.yml
@@ -14,5 +14,3 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.7
       - uses: ./
-        env:
-          GH_TOKEN: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -28,6 +28,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
       - uses: schubergphilis/mcvs-pr-validation-action@v0.1.0
-        env:
-          GH_TOKEN: ${{ github.token }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,8 @@ runs:
   using: composite
   steps:
     - name: Check whether PR description is nonempty
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
         PR_NUMBER="${GITHUB_REF_NAME/\/merge/}"
         if [[ ! ${PR_NUMBER} =~ ^[0-9]+$ ]]; then


### PR DESCRIPTION
This PR removed the superfluous definition of `GH_TOKEN: ${{ github.token }}` by moving it to the action.yml and make it implicit.